### PR TITLE
Feature/implement on error

### DIFF
--- a/src/yaml_workflow/workspace.py
+++ b/src/yaml_workflow/workspace.py
@@ -142,11 +142,29 @@ class WorkflowState:
             "completed_steps": [],
             "failed_step": None,
             "step_outputs": {},
+            "retry_state": {},  # Add retry state tracking
             "last_updated": datetime.now().isoformat(),
             "status": "not_started",
             "flow": None,
         }
         self.save()
+
+    def get_retry_state(self, step_name: str) -> Dict[str, Any]:
+        """Get retry state for a step."""
+        return self.metadata["execution_state"].get("retry_state", {}).get(step_name, {})
+
+    def update_retry_state(self, step_name: str, retry_state: Dict[str, Any]) -> None:
+        """Update retry state for a step."""
+        if "retry_state" not in self.metadata["execution_state"]:
+            self.metadata["execution_state"]["retry_state"] = {}
+        self.metadata["execution_state"]["retry_state"][step_name] = retry_state
+        self.save()
+
+    def clear_retry_state(self, step_name: str) -> None:
+        """Clear retry state for a step."""
+        if "retry_state" in self.metadata["execution_state"]:
+            self.metadata["execution_state"]["retry_state"].pop(step_name, None)
+            self.save()
 
 
 def sanitize_name(name: str) -> str:

--- a/src/yaml_workflow/workspace.py
+++ b/src/yaml_workflow/workspace.py
@@ -151,7 +151,9 @@ class WorkflowState:
 
     def get_retry_state(self, step_name: str) -> Dict[str, Any]:
         """Get retry state for a step."""
-        return self.metadata["execution_state"].get("retry_state", {}).get(step_name, {})
+        return (
+            self.metadata["execution_state"].get("retry_state", {}).get(step_name, {})
+        )
 
     def update_retry_state(self, step_name: str, retry_state: Dict[str, Any]) -> None:
         """Update retry state for a step."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -209,3 +209,52 @@ def test_workflow_flow_tracking(workflow_state):
     # Clear flow
     workflow_state.set_flow(None)
     assert workflow_state.get_flow() is None
+
+
+def test_retry_state_management(workflow_state):
+    """Test retry state management."""
+    # Test updating retry state
+    retry_state = {
+        "attempt": 1,
+        "last_error": "Test error",
+        "last_attempt": "2024-01-01T00:00:00"
+    }
+    workflow_state.update_retry_state("step1", retry_state)
+    
+    # Verify retry state was saved
+    state = workflow_state.get_retry_state("step1")
+    assert state == retry_state
+    
+    # Test updating attempt count
+    retry_state["attempt"] = 2
+    workflow_state.update_retry_state("step1", retry_state)
+    state = workflow_state.get_retry_state("step1")
+    assert state["attempt"] == 2
+    
+    # Test clearing retry state
+    workflow_state.clear_retry_state("step1")
+    state = workflow_state.get_retry_state("step1")
+    assert state == {}
+    
+    # Test getting retry state for non-existent step
+    state = workflow_state.get_retry_state("non_existent")
+    assert state == {}
+
+
+def test_retry_state_reset(workflow_state):
+    """Test retry state is reset when workflow state is reset."""
+    # Set up some retry state
+    retry_state = {
+        "attempt": 1,
+        "last_error": "Test error",
+        "last_attempt": "2024-01-01T00:00:00"
+    }
+    workflow_state.update_retry_state("step1", retry_state)
+    
+    # Reset workflow state
+    workflow_state.reset_state()
+    
+    # Verify retry state was cleared
+    state = workflow_state.get_retry_state("step1")
+    assert state == {}
+    assert workflow_state.metadata["execution_state"]["retry_state"] == {}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -217,25 +217,25 @@ def test_retry_state_management(workflow_state):
     retry_state = {
         "attempt": 1,
         "last_error": "Test error",
-        "last_attempt": "2024-01-01T00:00:00"
+        "last_attempt": "2024-01-01T00:00:00",
     }
     workflow_state.update_retry_state("step1", retry_state)
-    
+
     # Verify retry state was saved
     state = workflow_state.get_retry_state("step1")
     assert state == retry_state
-    
+
     # Test updating attempt count
     retry_state["attempt"] = 2
     workflow_state.update_retry_state("step1", retry_state)
     state = workflow_state.get_retry_state("step1")
     assert state["attempt"] == 2
-    
+
     # Test clearing retry state
     workflow_state.clear_retry_state("step1")
     state = workflow_state.get_retry_state("step1")
     assert state == {}
-    
+
     # Test getting retry state for non-existent step
     state = workflow_state.get_retry_state("non_existent")
     assert state == {}
@@ -247,13 +247,13 @@ def test_retry_state_reset(workflow_state):
     retry_state = {
         "attempt": 1,
         "last_error": "Test error",
-        "last_attempt": "2024-01-01T00:00:00"
+        "last_attempt": "2024-01-01T00:00:00",
     }
     workflow_state.update_retry_state("step1", retry_state)
-    
+
     # Reset workflow state
     workflow_state.reset_state()
-    
+
     # Verify retry state was cleared
     state = workflow_state.get_retry_state("step1")
     assert state == {}


### PR DESCRIPTION
This pull request introduces significant improvements to error handling and retry mechanisms in the `yaml_workflow` engine. The changes include adding a new method to handle step errors, updating the workflow state management to track retry attempts, and enhancing the test coverage to verify the new functionalities.

Key changes include:

### Error Handling Enhancements:
* Added `_handle_step_error` method to manage step errors based on the `on_error` configuration, supporting actions like `fail`, `continue`, `retry`, and `notify`.

### State Management:
* Updated `reset_state` method in `src/yaml_workflow/workspace.py` to include retry state tracking. Added methods to get, update, and clear retry state for steps.

### Test Coverage:
* Expanded test suite in `tests/test_engine.py` to cover various `on_error` actions, including `fail`, `continue`, `retry`, and `notify`, as well as template message rendering.
* Added tests in `tests/test_state.py` to verify retry state management and ensure retry state is reset correctly.

### Minor Changes:
* Imported `time` module in `src/yaml_workflow/engine.py` to support delay in retry logic.
* Included `FlowNotFoundError` import in `tests/test_engine.py` for comprehensive exception handling.