### PR TITLE
chore(release): bump version to 0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yaml-workflow"
-version = "0.9.2"
+version = "0.9.3"
 description = "A lightweight workflow engine for CI/CD pipelines, data processing, and DevOps automation — define tasks in YAML, run anywhere"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the v0.9.3 patch release: bump `pyproject.toml` 0.9.2 → 0.9.3.

Per [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) § Release Process, a release is: (1) update version in `pyproject.toml`, (2) tag matching the version, which triggers `release.yml` (GitHub release) and `publish.yml` (PyPI). `release.yml` hard-fails if the tag doesn't match the package version, so this bump must land on `main` first.

This bump-only PR matches the last several releases (0.8.x–0.9.2), which did not touch `CHANGELOG.md` (release notes are GitHub auto-generated). Note: `scripts/release.sh` is stale — it assumes the pre-0.8.0 `-dev` suffix flow and pushes directly to `main`, which branch protection now blocks; do not use it.

## Included since v0.9.2

- fix(engine): mask declared secrets in dry-run previews and param-default logs (#36)
- fix: clear 26 CodeQL clear-text-logging false positives (#35) — tests only
- 7 dependency-group bumps (#25, #27, #29, #30, #31, #33, #34)

## After merge

```bash
git fetch origin main && git tag v0.9.3 origin/main && git push origin v0.9.3
```