### PR TITLE
docs: address Copilot review on editor-integration guide

### DIFF
--- a/docs/guide/editor-integration.md
+++ b/docs/guide/editor-integration.md
@@ -33,10 +33,12 @@ steps:
 ```
 
 Prefer a local copy (e.g. offline, or to pin a version)? Point at a schema file
-on disk with a path relative to the workflow file:
+on disk with a path **relative to the workflow file**. For example, if your
+workflows live in a `workflows/` directory and the schema is at the project
+root, use `../schema/...`:
 
 ```yaml
-# yaml-language-server: $schema=./schema/workflow-schema.json
+# yaml-language-server: $schema=../schema/workflow-schema.json
 ```
 
 The schema is also bundled inside the installed package (at
@@ -53,6 +55,7 @@ and map the schema to your workflow files in `.vscode/settings.json`:
   "yaml.schemas": {
     "https://raw.githubusercontent.com/orieg/yaml-workflow/main/schema/workflow-schema.json": [
       "**/*.yaml-workflow.yaml",
+      "**/*.yaml-workflow.yml",
       "workflows/**/*.yaml"
     ]
   }


### PR DESCRIPTION
Follow-up to #39 (merged) addressing Copilot's two doc-consistency comments:

- **Local-schema modeline example** used `./schema/...`, which wouldn't resolve for workflow files under `workflows/` (the layout the rest of the page uses). Changed to `../schema/...` with an explicit note that the path is relative to the workflow file.
- **VS Code `yaml.schemas` example** listed only the `.yaml-workflow.yaml` pattern; added `.yaml-workflow.yml` to match the documented convention.

Docs-only; `mkdocs build` succeeds.