### PR TITLE
feat(mcp): prepare official MCP Registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,43 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true 
+          skip-existing: true
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: build-and-publish
+    # Only for real version tags (not -test); the registry verifies the
+    # mcp-name marker against the just-published PyPI release.
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-test') }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC auth to the MCP registry
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Sync server.json version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: |
+          # Retry to absorb the short delay before the new PyPI release
+          # (and its mcp-name marker) is indexed for ownership verification.
+          for i in 1 2 3 4 5; do
+            if ./mcp-publisher publish; then exit 0; fi
+            echo "publish attempt $i failed; PyPI release may not be indexed yet — retrying in 30s"
+            sleep 30
+          done
+          echo "MCP registry publish failed after retries" >&2
+          exit 1 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YAML Workflow
 
+<!-- mcp-name: io.github.orieg/yaml-workflow -->
+
 [![PyPI version](https://img.shields.io/pypi/v/yaml-workflow.svg)](https://pypi.org/project/yaml-workflow/)
 [![Python versions](https://img.shields.io/pypi/pyversions/yaml-workflow.svg)](https://pypi.org/project/yaml-workflow/)
 [![CI](https://github.com/orieg/yaml-workflow/actions/workflows/ci.yml/badge.svg)](https://github.com/orieg/yaml-workflow/actions/workflows/ci.yml)

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -1,14 +1,17 @@
 # MCP Server Integration
 
-yaml-workflow can expose workflows as MCP (Model Context Protocol) tools, making them
-discoverable by AI agents like Claude Desktop and Claude Code.
+yaml-workflow can expose your workflows as [MCP](https://modelcontextprotocol.io)
+(Model Context Protocol) tools, making them discoverable and callable by AI
+agents like Claude Code, Claude Desktop, and Cursor. Each workflow in a
+directory becomes a typed tool the agent can run.
 
 ## Installation
 
-The MCP server requires the `mcp` extra:
+The MCP server requires the `mcp` extra (kept optional so the core engine stays
+at two dependencies):
 
 ```bash
-pipx install 'yaml-workflow[mcp]'   # or yaml-workflow[all]
+pipx install 'yaml-workflow[mcp]'   # or 'yaml-workflow[all]'
 # or
 pip install 'yaml-workflow[mcp]'
 ```
@@ -21,17 +24,31 @@ Point the MCP server at a directory of workflow YAML files:
 yaml-workflow serve-mcp --dir workflows/
 ```
 
-## How It Works
+The server speaks MCP over stdio, so it is launched by the MCP client rather
+than run standalone (see the client configs below).
 
-- Scans the directory for workflow YAML files.
-- Each workflow becomes an MCP tool, named after the workflow file.
-- Workflow `params` become tool input parameters with types and descriptions.
-- Running a tool executes the workflow and returns results as JSON.
+## How it works
 
-## Claude Desktop Configuration
+- Scans the directory for workflow YAML files (any `*.yaml` with a `steps:` key).
+- Each workflow becomes an MCP tool, named after the workflow's `name`.
+- Workflow `params` become the tool's input parameters, with types and
+  descriptions carried through to the agent.
+- Calling a tool runs the workflow and returns the step outputs as JSON.
 
-Add yaml-workflow to your Claude Desktop MCP config
-(`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+## Client configuration
+
+All MCP clients launch the server the same way — the command `yaml-workflow`
+with `serve-mcp --dir <your-workflows>`. Install the `[mcp]` extra first (above).
+
+### Claude Code
+
+```bash
+claude mcp add yaml-workflow -- yaml-workflow serve-mcp --dir /path/to/workflows
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
 
 ```json
 {
@@ -44,6 +61,44 @@ Add yaml-workflow to your Claude Desktop MCP config
 }
 ```
 
-Once configured, Claude Desktop will discover every workflow in the directory as a
-callable tool. Workflow descriptions and parameter metadata appear in the tool list
+### Cursor / other stdio clients
+
+Any client that speaks MCP over stdio uses the same shape:
+
+```json
+{
+  "mcpServers": {
+    "yaml-workflow": {
+      "command": "yaml-workflow",
+      "args": ["serve-mcp", "--dir", "/path/to/workflows"]
+    }
+  }
+}
+```
+
+Once configured, the client discovers every workflow in the directory as a
+callable tool; descriptions and parameter metadata appear in the tool list
 automatically.
+
+## Install from the MCP Registry
+
+yaml-workflow is published to the [official MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.github.orieg/yaml-workflow`. Clients that browse the registry can install
+it directly. The registry launches it with [`uvx`](https://docs.astral.sh/uv/),
+pulling the `[mcp]` extra:
+
+```bash
+uvx --from 'yaml-workflow[mcp]' yaml-workflow serve-mcp --dir workflows/
+```
+
+If your client does not compose the `--from` extra automatically, fall back to
+the explicit install (`pip install 'yaml-workflow[mcp]'`) plus one of the client
+configs above.
+
+## Security
+
+The MCP server lets a connected agent **execute the workflows in the directory
+you serve** — which may run shell commands and Python. Only serve workflows you
+trust, run the server with least privilege, and treat parameters coming from an
+agent as untrusted input. See the [Security Policy](https://github.com/orieg/yaml-workflow/blob/main/SECURITY.md)
+for the full execution model.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.orieg/yaml-workflow",
+  "title": "YAML Workflow",
+  "description": "Expose declarative YAML-defined workflows as MCP tools over stdio",
+  "version": "0.9.4",
+  "repository": {
+    "url": "https://github.com/orieg/yaml-workflow",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "yaml-workflow",
+      "version": "0.9.4",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "description": "Install the package with the [mcp] extra so the serve-mcp command is available",
+          "value": "yaml-workflow[mcp]"
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve-mcp"
+        },
+        {
+          "type": "named",
+          "name": "--dir",
+          "description": "Directory containing workflow YAML definitions to expose as tools",
+          "isRequired": true,
+          "value": "{workflow_dir}",
+          "variables": {
+            "workflow_dir": {
+              "description": "Path to the directory of workflow definitions",
+              "format": "filepath",
+              "isRequired": true,
+              "default": "workflows"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares publishing yaml-workflow's MCP server to the [official MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.orieg/yaml-workflow` — the strongest AI-agent-adoption lever, since it lets agents discover and run the server without needing to recall the API. In-repo prep only; **activation happens automatically on the next release** (the registry verifies ownership against the just-published PyPI package, so the marker must be live there first).

## Changes

- **`server.json`** (repo root) — the registry manifest. Validated locally with `mcp-publisher` 1.8.1 against schema `2025-12-11` (`✅ server.json is valid`). PyPI package, stdio transport, `uvx` runtime.
- **README `mcp-name` marker** — `<!-- mcp-name: io.github.orieg/yaml-workflow -->`, the registry's PyPI ownership-verification token. On its own line per the boundary rule.
- **`publish.yml`** — new `publish-mcp-registry` job that `needs` the PyPI publish (so a registry hiccup can't break a release), runs only on real `v*` tags, syncs `server.json` version from the tag, authenticates via **GitHub OIDC** (no stored secret), and retries to absorb PyPI indexing lag.
- **`docs/guide/mcp.md`** — expanded from Claude-Desktop-only to: registry/`uvx` install, Claude Code (`claude mcp add`) / Claude Desktop / Cursor configs, and a **security note** on agent-triggered execution (links SECURITY.md).

## Decisions & caveats

- **Kept `[mcp]` optional** (core stays at 2 deps — preserves the "lightweight vs Airflow" positioning). The registry launch therefore uses `uvx --from yaml-workflow[mcp]`. Its composition across every MCP client is the one thing I couldn't verify from primary docs — the docs prominently give the explicit `pip install 'yaml-workflow[mcp]'` + client-config path as the tested fallback.
- **Prerequisite:** the first release after this merges will carry the marker in its PyPI description; the publish job then succeeds. Nothing to publish before that release.

## Verification
- `mcp-publisher validate server.json` → valid.
- `publish.yml` parses; new job wired with `id-token: write`, `needs: build-and-publish`.
- `mkdocs build` succeeds; `server.json` correctly excluded from the wheel (registry metadata, not package content).
