### PR TITLE
fix(mcp): address Copilot review on #41

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,11 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          set -euo pipefail
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz" -o mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc

--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -82,10 +82,11 @@ automatically.
 
 ## Install from the MCP Registry
 
-yaml-workflow is published to the [official MCP Registry](https://registry.modelcontextprotocol.io)
-as `io.github.orieg/yaml-workflow`. Clients that browse the registry can install
-it directly. The registry launches it with [`uvx`](https://docs.astral.sh/uv/),
-pulling the `[mcp]` extra:
+yaml-workflow publishes its MCP server to the [official MCP Registry](https://registry.modelcontextprotocol.io)
+as `io.github.orieg/yaml-workflow` (available from the next release onward).
+Once listed, clients that browse the registry can install it directly. The
+registry launches it with [`uvx`](https://docs.astral.sh/uv/), pulling the
+`[mcp]` extra:
 
 ```bash
 uvx --from 'yaml-workflow[mcp]' yaml-workflow serve-mcp --dir workflows/

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.orieg/yaml-workflow",
   "title": "YAML Workflow",
   "description": "Expose declarative YAML-defined workflows as MCP tools over stdio",
-  "version": "0.9.4",
+  "version": "0.9.3",
   "repository": {
     "url": "https://github.com/orieg/yaml-workflow",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "yaml-workflow",
-      "version": "0.9.4",
+      "version": "0.9.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Follow-up to #41 (merged), addressing Copilot's three comments:

- **server.json version** was 0.9.4 while pyproject is 0.9.3 — set to 0.9.3 for local consistency. (The publish job still overwrites it from the release tag, so publishing uses the real release version.)
- **mcp-publisher install** piped curl into `tar xz` (stdin extraction is fragile and masks curl failures). Now downloads to a file and extracts with `tar -xzf`, under `set -euo pipefail`.
- **mcp.md** said the server "is published" to the registry; reworded to future tense since the listing activates on the next release.

Verified: `mcp-publisher validate server.json` passes; `publish.yml` parses; `mkdocs build` succeeds.