### PR TITLE
feat(mcp): discovery/validate/dry-run/run meta-tools + Glama metadata

### DIFF
--- a/docs/guide/mcp.md
+++ b/docs/guide/mcp.md
@@ -27,13 +27,26 @@ yaml-workflow serve-mcp --dir workflows/
 The server speaks MCP over stdio, so it is launched by the MCP client rather
 than run standalone (see the client configs below).
 
-## How it works
+## Tools
 
-- Scans the directory for workflow YAML files (any `*.yaml` with a `steps:` key).
-- Each workflow becomes an MCP tool, named after the workflow's `name`.
-- Workflow `params` become the tool's input parameters, with types and
-  descriptions carried through to the agent.
-- Calling a tool runs the workflow and returns the step outputs as JSON.
+The server exposes four **meta-tools** that work regardless of what is in the
+directory, so an agent can discover, check, preview, and run workflows:
+
+| Tool | Read-only? | What it does |
+|------|-----------|--------------|
+| `list_workflows` | ✅ | Lists the workflows in the directory with their names, descriptions, and declared parameters. |
+| `validate_workflow` | ✅ | Validates a workflow YAML file (by path) and returns structured errors/warnings. |
+| `dry_run_workflow` | ✅ | Previews the steps a workflow would run (and their resolved inputs) without executing anything. |
+| `run_workflow` | ❌ | Executes a workflow (by name or path) with optional params and returns each step's output. |
+
+In addition, **each workflow file in the directory becomes its own convenience
+tool** named after the workflow, so a workflow can be invoked directly with its
+declared parameters as typed inputs. `run_workflow` is the generic equivalent.
+
+Tools are annotated with MCP hints (`readOnlyHint` / `destructiveHint`) so clients
+can distinguish safe introspection (`list_workflows`, `validate_workflow`,
+`dry_run_workflow`) from execution (`run_workflow` and the per-workflow tools),
+which may run shell commands and Python — see [Security](#security).
 
 ## Client configuration
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["orieg"]
+}

--- a/src/yaml_workflow/mcp_server.py
+++ b/src/yaml_workflow/mcp_server.py
@@ -3,14 +3,17 @@
 Usage:
     yaml-workflow serve-mcp --dir workflows/
 
-Each workflow YAML file in the directory becomes an MCP tool. Workflow
-params become tool input parameters. Running a tool executes the
-workflow and returns results as JSON.
+The server exposes a fixed set of meta-tools for discovering, validating,
+previewing, and running workflows (``list_workflows``, ``validate_workflow``,
+``dry_run_workflow``, ``run_workflow``), plus one convenience tool per workflow
+YAML file found in the served directory. Running a workflow executes it and
+returns its step outputs as JSON.
 """
 
+import contextlib
+import io
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -103,6 +106,82 @@ def _params_to_schema(params: dict) -> dict:
     return schema
 
 
+def _tool_name(workflow_name: str) -> str:
+    """Derive a stable snake_case MCP tool name from a workflow name."""
+    return workflow_name.lower().replace(" ", "_").replace("-", "_")
+
+
+# Reserved meta-tool names that a per-workflow tool must not shadow.
+_META_TOOL_NAMES = {
+    "list_workflows",
+    "validate_workflow",
+    "dry_run_workflow",
+    "run_workflow",
+}
+
+
+def _resolve_workflow(workflow: Optional[str], directory: str) -> Optional[str]:
+    """Resolve a workflow reference to a file path.
+
+    Accepts either a direct path to a YAML file or the ``name`` of a workflow in
+    the served directory (matched by its declared name or its snake_case tool
+    name). Returns the resolved path, or None if it cannot be found.
+    """
+    if not workflow:
+        return None
+    candidate = Path(workflow)
+    if candidate.is_file():
+        return str(candidate)
+    target = _tool_name(workflow)
+    for wf in _scan_workflows(directory):
+        if wf["name"] == workflow or _tool_name(wf["name"]) == target:
+            return wf["path"]
+    return None
+
+
+def _validate_workflow(path: str) -> Dict[str, Any]:
+    """Validate a workflow file and return the structured result."""
+    from .validator import WorkflowValidator
+
+    return WorkflowValidator(path).validate().to_dict()
+
+
+def _execute_workflow(
+    path: str,
+    params: Optional[dict],
+    base_dir: str,
+    dry_run: bool,
+) -> Dict[str, Any]:
+    """Run (or dry-run) a workflow, returning a compact JSON-friendly result.
+
+    Engine stdout (e.g. the dry-run preview) is captured so it cannot corrupt
+    the MCP stdio JSON-RPC stream; for a dry run it is returned as ``preview``.
+    """
+    from .engine import WorkflowEngine
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        engine = WorkflowEngine(path, base_dir=base_dir, dry_run=dry_run)
+        result = engine.run(params=params or {})
+
+    outputs: Dict[str, Any] = {}
+    for step_name, data in (result.get("outputs") or {}).items():
+        if isinstance(data, dict) and "result" in data:
+            outputs[step_name] = data["result"]
+        else:
+            outputs[step_name] = data
+
+    response: Dict[str, Any] = {
+        "status": result.get("status", "unknown"),
+        "outputs": outputs,
+    }
+    if dry_run:
+        preview = buffer.getvalue().strip()
+        if preview:
+            response["preview"] = preview
+    return response
+
+
 async def serve(directory: str, base_dir: str = "runs") -> None:
     """Start the MCP server exposing workflows as tools.
 
@@ -113,89 +192,219 @@ async def serve(directory: str, base_dir: str = "runs") -> None:
     try:
         from mcp.server import Server
         from mcp.server.stdio import stdio_server
-        from mcp.types import TextContent, Tool
+        from mcp.types import TextContent, Tool, ToolAnnotations
     except ImportError:
         raise ImportError(
             "MCP server requires the 'mcp' package. "
             "Install it with: pip install 'yaml-workflow[mcp]'"
         )
 
-    from .engine import WorkflowEngine
-
     server = Server("yaml-workflow")
     workflow_dir = directory
 
+    read_only = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+    destructive = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=True,
+        idempotentHint=False,
+        openWorldHint=True,
+    )
+
+    workflow_arg_schema = {
+        "type": "object",
+        "properties": {
+            "workflow": {
+                "type": "string",
+                "description": (
+                    "Workflow to target: either a name returned by "
+                    "list_workflows, or a path to a workflow YAML file."
+                ),
+            },
+            "params": {
+                "type": "object",
+                "description": (
+                    "Optional values for the workflow's declared inputs, as an "
+                    "object of name -> value. Omit to use each parameter's default."
+                ),
+            },
+        },
+        "required": ["workflow"],
+    }
+
+    def _meta_tools() -> List["Tool"]:
+        return [
+            Tool(
+                name="list_workflows",
+                description=(
+                    "List the workflows available in this server's workflow "
+                    "directory. Returns an array with one object per workflow, "
+                    "each containing `name` (its declared name), `description`, "
+                    "`path` (the YAML file), and `parameters` (declared inputs "
+                    "with types and defaults). Call this first to discover which "
+                    "workflows exist and what inputs each accepts before calling "
+                    "dry_run_workflow or run_workflow. Read-only: it only reads "
+                    "YAML files and never executes anything. Takes no arguments."
+                ),
+                inputSchema={"type": "object", "properties": {}},
+                annotations=read_only,
+            ),
+            Tool(
+                name="validate_workflow",
+                description=(
+                    "Validate a single workflow YAML file without running it. "
+                    "Give the file `path`; returns "
+                    "`{valid, error_count, warning_count, issues[]}`, where each "
+                    "issue has a level (error/warning/info), message, and optional "
+                    "line, step, and hint. Use this to check a workflow the agent "
+                    "authored or edited before running it, or to explain why a "
+                    "workflow is malformed. Read-only: no tasks run and nothing "
+                    "is written."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Path to the workflow YAML file to validate.",
+                        }
+                    },
+                    "required": ["path"],
+                },
+                annotations=read_only,
+            ),
+            Tool(
+                name="dry_run_workflow",
+                description=(
+                    "Preview what a workflow would do without executing any task. "
+                    "Give a `workflow` (a name from list_workflows or a file path) "
+                    "and optional `params`; returns `{status, outputs, preview}` "
+                    "where `preview` is a human-readable list of the steps that "
+                    "would run with their resolved inputs (the same information as "
+                    "the CLI's --dry-run). Use this to inspect side effects (shell "
+                    "commands, file writes, HTTP calls) before running for real. "
+                    "Read-only: no shell or Python is executed and no files are "
+                    "written."
+                ),
+                inputSchema=workflow_arg_schema,
+                annotations=read_only,
+            ),
+            Tool(
+                name="run_workflow",
+                description=(
+                    "Execute a workflow and return its results. Give a `workflow` "
+                    "(a name from list_workflows or a file path) and optional "
+                    "`params`; runs it to completion and returns "
+                    "`{status, workflow, outputs}` where `outputs` maps each step "
+                    "name to its result. DESTRUCTIVE: a workflow may run arbitrary "
+                    "shell commands and Python, write files, and make HTTP "
+                    "requests — call dry_run_workflow first if you need to preview "
+                    "side effects, and only run workflows you trust."
+                ),
+                inputSchema=workflow_arg_schema,
+                annotations=destructive,
+            ),
+        ]
+
     @server.list_tools()
     async def list_tools() -> list:
-        """Return available workflow tools."""
-        workflows = _scan_workflows(workflow_dir)
-        tools = []
-        for wf in workflows:
-            tool_name = wf["name"].lower().replace(" ", "_").replace("-", "_")
+        """Return the meta-tools plus one convenience tool per workflow."""
+        tools = _meta_tools()
+        for wf in _scan_workflows(workflow_dir):
+            name = _tool_name(wf["name"])
+            if name in _META_TOOL_NAMES:
+                # Don't let a workflow named e.g. "run workflow" shadow a meta-tool.
+                name = f"workflow_{name}"
+            base = wf["description"] or f"Run the '{wf['name']}' workflow."
             tools.append(
                 Tool(
-                    name=tool_name,
-                    description=wf["description"] or f"Run the {wf['name']} workflow",
+                    name=name,
+                    description=(
+                        f"{base} Executes the '{wf['name']}' workflow and returns "
+                        "its step outputs as JSON. This runs the workflow's tasks "
+                        "(which may include shell commands, Python, and HTTP "
+                        "requests). Equivalent to run_workflow with "
+                        f'workflow="{wf["name"]}".'
+                    ),
                     inputSchema=_params_to_schema(wf["params"]),
+                    annotations=destructive,
                 )
             )
         return tools
 
+    def _text(payload: Dict[str, Any]) -> list:
+        return [
+            TextContent(type="text", text=json.dumps(payload, indent=2, default=str))
+        ]
+
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list:
-        """Execute a workflow tool."""
-        workflows = _scan_workflows(workflow_dir)
+        """Dispatch a tool call to a meta-tool or a per-workflow run."""
+        arguments = arguments or {}
 
-        # Find matching workflow
-        target = None
-        for wf in workflows:
-            tool_name = wf["name"].lower().replace(" ", "_").replace("-", "_")
-            if tool_name == name:
-                target = wf
-                break
-
-        if target is None:
-            return [
-                TextContent(
-                    type="text",
-                    text=json.dumps({"error": f"Workflow '{name}' not found"}),
-                )
+        if name == "list_workflows":
+            workflows = [
+                {
+                    "name": wf["name"],
+                    "description": wf["description"],
+                    "path": wf["path"],
+                    "parameters": wf["params"],
+                }
+                for wf in _scan_workflows(workflow_dir)
             ]
+            return _text({"workflows": workflows, "count": len(workflows)})
 
-        try:
-            engine = WorkflowEngine(
-                target["path"],
-                base_dir=base_dir,
-            )
-            results = engine.run(**arguments)
+        if name == "validate_workflow":
+            path = arguments.get("path")
+            if not path or not Path(path).is_file():
+                return _text({"error": f"Workflow file not found: {path!r}"})
+            try:
+                return _text(_validate_workflow(path))
+            except Exception as e:  # noqa: BLE001 - surfaced to the agent
+                return _text({"error": str(e)})
 
-            # Extract step outputs
-            outputs = {}
-            if results and results.get("outputs"):
-                for step_name, step_data in results["outputs"].items():
-                    if isinstance(step_data, dict) and "result" in step_data:
-                        outputs[step_name] = step_data["result"]
-                    else:
-                        outputs[step_name] = step_data
+        if name in ("dry_run_workflow", "run_workflow"):
+            workflow = arguments.get("workflow")
+            path = _resolve_workflow(workflow, workflow_dir)
+            if path is None:
+                return _text({"error": f"Workflow not found: {workflow!r}"})
+            params = arguments.get("params") or {}
+            try:
+                result = _execute_workflow(
+                    path,
+                    params,
+                    base_dir=base_dir,
+                    dry_run=(name == "dry_run_workflow"),
+                )
+                result["workflow"] = workflow
+                return _text(result)
+            except Exception as e:  # noqa: BLE001 - surfaced to the agent
+                return _text(
+                    {"status": "failed", "workflow": workflow, "error": str(e)}
+                )
 
-            response = {
-                "status": "success",
-                "workflow": target["name"],
-                "outputs": outputs,
-            }
-        except Exception as e:
-            response = {
-                "status": "failed",
-                "workflow": target["name"],
-                "error": str(e),
-            }
+        # Otherwise: a per-workflow convenience tool. Match by tool name.
+        for wf in _scan_workflows(workflow_dir):
+            wf_tool = _tool_name(wf["name"])
+            if wf_tool in _META_TOOL_NAMES:
+                wf_tool = f"workflow_{wf_tool}"
+            if wf_tool == name:
+                try:
+                    result = _execute_workflow(
+                        wf["path"], arguments, base_dir=base_dir, dry_run=False
+                    )
+                    result["workflow"] = wf["name"]
+                    return _text(result)
+                except Exception as e:  # noqa: BLE001 - surfaced to the agent
+                    return _text(
+                        {"status": "failed", "workflow": wf["name"], "error": str(e)}
+                    )
 
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(response, indent=2, default=str),
-            )
-        ]
+        return _text({"error": f"Unknown tool: {name!r}"})
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,7 +3,19 @@
 import pytest
 import yaml
 
-from yaml_workflow.mcp_server import _params_to_schema, _scan_workflows
+from yaml_workflow.mcp_server import (
+    _execute_workflow,
+    _params_to_schema,
+    _resolve_workflow,
+    _scan_workflows,
+    _tool_name,
+    _validate_workflow,
+)
+
+
+def _write_wf(path, body):
+    path.write_text(body)
+    return str(path)
 
 
 class TestScanWorkflows:
@@ -65,3 +77,71 @@ class TestParamsToSchema:
         schema = _params_to_schema({"name": "default_value"})
         assert schema["properties"]["name"]["type"] == "string"
         assert schema["properties"]["name"]["default"] == "default_value"
+
+
+_RUNNABLE_WF = (
+    "name: Greeter\n"
+    "description: Says hi\n"
+    "params:\n"
+    "  who:\n"
+    "    type: string\n"
+    "    default: World\n"
+    "steps:\n"
+    "  - name: compute\n"
+    "    task: python_code\n"
+    "    inputs:\n"
+    "      code: |\n"
+    '        result = "hi"\n'
+)
+
+
+class TestToolName:
+    def test_snake_case(self):
+        assert _tool_name("Data Pipeline") == "data_pipeline"
+        assert _tool_name("ai-changelog") == "ai_changelog"
+
+
+class TestResolveWorkflow:
+    def test_resolve_by_path(self, tmp_path):
+        p = _write_wf(tmp_path / "w.yaml", _RUNNABLE_WF)
+        assert _resolve_workflow(p, str(tmp_path)) == p
+
+    def test_resolve_by_name(self, tmp_path):
+        p = _write_wf(tmp_path / "w.yaml", _RUNNABLE_WF)
+        assert _resolve_workflow("Greeter", str(tmp_path)) == p
+        assert _resolve_workflow("greeter", str(tmp_path)) == p
+
+    def test_resolve_not_found(self, tmp_path):
+        assert _resolve_workflow("nope", str(tmp_path)) is None
+        assert _resolve_workflow("", str(tmp_path)) is None
+
+
+class TestValidateWorkflow:
+    def test_valid(self, tmp_path):
+        p = _write_wf(tmp_path / "w.yaml", _RUNNABLE_WF)
+        result = _validate_workflow(p)
+        assert result["valid"] is True
+        assert result["error_count"] == 0
+
+    def test_invalid(self, tmp_path):
+        p = _write_wf(tmp_path / "bad.yaml", "name: Bad\nsteps: not-a-list\n")
+        result = _validate_workflow(p)
+        assert result["valid"] is False
+        assert result["error_count"] >= 1
+
+
+class TestExecuteWorkflow:
+    def test_run_returns_outputs(self, tmp_path):
+        p = _write_wf(tmp_path / "w.yaml", _RUNNABLE_WF)
+        result = _execute_workflow(
+            p, {}, base_dir=str(tmp_path / "runs"), dry_run=False
+        )
+        assert result["status"] in ("completed", "success")
+        assert result["outputs"]["compute"] == "hi"
+        assert "preview" not in result
+
+    def test_dry_run_previews_without_executing(self, tmp_path):
+        p = _write_wf(tmp_path / "w.yaml", _RUNNABLE_WF)
+        result = _execute_workflow(p, {}, base_dir=str(tmp_path / "runs"), dry_run=True)
+        assert "preview" in result
+        assert "DRY-RUN" in result["preview"]


### PR DESCRIPTION
## Summary

Makes the MCP server a first-class agent surface — and prepares it for a Glama **A-grade** (the awesome-mcp-servers badge gate) by ensuring `tools/list` is non-empty and every tool is well-described with correct annotations.

Previously the server exposed **only one tool per workflow file**, so:
- An empty directory produced **zero tools** — nothing for Glama (or any agent) to introspect or grade.
- An agent could *run* a workflow but couldn't **discover, validate, or preview** one (the #1 gap from the earlier MCP audit).

## Changes

- **Four always-present meta-tools** with rich, Glama-graded descriptions and correct MCP annotations:
  | Tool | Annotation | |
  |---|---|---|
  | `list_workflows` | read-only | discover workflows + their params |
  | `validate_workflow` | read-only | structured validation of a file |
  | `dry_run_workflow` | read-only | preview steps without executing |
  | `run_workflow` | **destructive** | execute by name/path with params |

  Descriptions and `readOnlyHint`/`destructiveHint` **agree** (no contradictions — a Glama scoring axis).
- **Latent bug fixed:** per-workflow execution called `engine.run(**arguments)`, but the signature is `run(params=...)` — any parameterized workflow would have raised `TypeError`. Now passes params correctly.
- **stdio safety:** engine stdout (e.g. the dry-run preview) is captured so it can't corrupt the JSON-RPC stream; returned as `preview` for dry runs.
- **Per-workflow convenience tools kept** (additive — no behavior removed).
- **`glama.json`** at repo root (maintainer `orieg`) for Glama server verification.
- Docs (`mcp.md`) document the tool model; new tests cover the resolve/validate/execute helpers.

## Verification
- 731 tests pass (7 benchmarks deselected); `black`/`isort`/`mypy` clean.
- End-to-end over MCP stdio: **4 meta-tools list with an empty directory**, unauthenticated; `run_workflow {who: Alice}` → `hi Alice`; per-workflow tool → `hi Bob`.

## Follow-up (needs maintainer's Glama login — Part 2/3 of the playbook)
After this merges + a release: claim the server on glama.ai, sync, configure the build (point `--dir` at an empty dir so only the four polished meta-tools are graded), build + publish a release to get the score, then append the Glama score badge to the awesome-mcp-servers PR entry (held pending the badge).
